### PR TITLE
Add recurring donations (subscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 ### Test
 
-Navigate to [http://localhost:5000/500](http://localhost:5000/500) to test. replace 500 with any integer value.
+Navigate to [http://localhost:5000/](http://localhost:5000/) to test. You can also use a donation
+amount as the path, e.g. [http://localhost:5000/123](http://localhost:5000/123) to prefill a $123
+donation.
 
 Currently, the only automated tests are doctests for the parse_cents module. These can be run with:
 
@@ -72,6 +74,10 @@ In [https://dashboard.stripe.com/webhooks](Webhooks), you should add an
 endpoint to the canonical host <https://donate.missionbit.com/hooks> for
 `checkout.session.completed` events and make note of the signing secret
 for use with the `WEBHOOK_SIGNING_SECRET` environment variable.
+
+For recurring donations, the app expects that there be a monthly plan
+with the id `mb-monthly-001` that is $0.01/mo. In our Mission Bit account,
+this plan should already be present in both test and live mode.
 
 ### Azure Configuration
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 ### Test
 
 Navigate to [http://localhost:5000/](http://localhost:5000/) to test. You can also use a donation
-amount as the path, e.g. [http://localhost:5000/123](http://localhost:5000/123) to prefill a $123
-donation.
+amount as the path, e.g. [http://localhost:5000/123/](http://localhost:5000/123/) to prefill a $123
+donation. The frequency can also be prefilled, e.g. [http://localhost:5000/123/?frequency=monthly](http://localhost:5000/123/?frequency=monthly).
 
 Currently, the only automated tests are doctests for the parse_cents module. These can be run with:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 4. ```$ source venv/bin/activate```
 5. ```$ pip install -r requirements.txt```
 6. Export enviroment variables (or create a [.env file](https://pypi.org/project/python-dotenv/)) including values for ```PUBLISHABLE_KEY```, ```SECRET_KEY```, ```WEBHOOK_SIGNING_SECRET```, ```APPINSIGHTS_INSTRUMENTATIONKEY```, and ```SENDGRID_API_KEY```
-7. ```$ FLASK_APP=application.py flask run```
+7. ```$ FLASK_APP=application.py FLASK_DEBUG=1 flask run```
 
 ### Test
 
@@ -23,6 +23,16 @@ Currently, the only automated tests are doctests for the parse_cents module. The
 ```shell
 $ python parse_cents.py
 …
+```
+
+### Testing Webhooks & Email
+
+Use the [Stripe CLI](https://stripe.com/docs/stripe-cli) to listen for webhooks while testing to
+ensure that emails are processed correctly.
+
+```console
+$ stripe listen --forward-to=http://localhost:5000/hooks
+> Ready! Your webhook signing secret is … (^C to quit)
 ```
 
 ### Coding Standards

--- a/application.py
+++ b/application.py
@@ -329,7 +329,9 @@ def stripe_webhook():
     event = None
     try:
         event = stripe.Webhook.construct_event(
-            payload, sig_header, stripe_keys['endpoint_secret']
+            payload=payload,
+            sig_header=sig_header,
+            secret=stripe_keys['endpoint_secret']
         )
     except ValueError as e:
         # Invalid payload
@@ -339,7 +341,7 @@ def stripe_webhook():
         return "Invalid signature", 400
     if event['type'] == 'checkout.session.completed':
         stripe_checkout_session_completed(event['data']['object'])
-    return "", 200
+    return jsonify({ 'status': 'success' })
 
 def host_default_amount(host):
     if host.startswith('gala.'):

--- a/application.py
+++ b/application.py
@@ -439,7 +439,11 @@ def stripe_webhook():
     }
     handler = handlers.get(event['type'])
     if handler is not None:
-        handler(event['data']['object'])
+        obj = event['data']['object']
+        print(f"handling {event['type']} id: {obj.id}")
+        handler(obj)
+    else:
+        print(f"{event['type']} not handled")
     return jsonify({ 'status': 'success' })
 
 def host_default_amount(host):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==0.10.3
 sendgrid==6.1.0
 jsonschema==3.1.1
 applicationinsights==0.11.9
+python-dateutil==2.8.1

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -141,11 +141,23 @@ body {
   z-index: 0;
 }
 
-.success-message {
+.success-message,
+.cancel-message {
   padding: 10px 0;
 }
 
-.success-message p {
+button.cancel-subscription {
+  background: none!important;
+  border: none;
+  padding: 0!important;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.success-message p,
+.cancel-message p {
   text-align: left;
   font-size: large;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -298,6 +298,25 @@ body {
   color: #DC139C;
 }
 
+.frequency-group {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 12px;
+  padding: 0 2px;
+}
+.frequency-group input {
+  margin: 0 10px 0 0;
+  font-size: 175%;
+}
+.frequency-group label {
+  font-size: 21px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}
+
 @media (max-width: 767px) {
   .org-info {
     font-size: 18px;

--- a/templates/cancel.html
+++ b/templates/cancel.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="donation">
+  <div class="donate-form-container">
+    <div class="donate-form-header">
+      <h2>Donation canceled</h2>
+    </div>
+    <div class="donate-form-body">
+      <div class="cancel-message">
+        <p>
+          Your donation has been canceled.
+          If you have any questions about donations, contact us at
+          <a href="mailto:{{ donate_email }}">{{ donate_email }}</a>.
+        </p>
+        <p>
+          From here you can <a href="/">donate</a> or visit
+          <a href="https://www.missionbit.com/">missionbit.com</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,10 @@
         </div>
         <div class="error"></div>
       </div>
+      <div class="frequency-group">
+        <label for="frequency_once"><input type="radio" name="frequency" value="once" id="frequency_once" checked /> One-time</label>
+        <label for="frequency_monthly"><input type="radio" name="frequency" value="monthly" id="frequency_monthly" /> Monthly</label>
+      </div>
       <div class="action-container">
         <button id="donate-button">Donate with card</span></button>
         <a href="#give-by-check" id="give-by-check-link">Give by check</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
             name="amount"
             required
             step="1"
-            value="{{ amount // 100 if amount else 50 }}"
+            value="{{ formatted_dollar_amount }}"
             aria-label="Donation Amount"
           />
           <span class="postinput">USD</span>
@@ -25,8 +25,8 @@
         <div class="error"></div>
       </div>
       <div class="frequency-group">
-        <label for="frequency_once"><input type="radio" name="frequency" value="once" id="frequency_once" checked /> One-time</label>
-        <label for="frequency_monthly"><input type="radio" name="frequency" value="monthly" id="frequency_monthly" /> Monthly</label>
+        <label for="frequency_once"><input type="radio" name="frequency" value="once" id="frequency_once" {% if frequency == "once" %}checked{% endif %} /> One-time</label>
+        <label for="frequency_monthly"><input type="radio" name="frequency" value="monthly" id="frequency_monthly" {% if frequency == "monthly" %}checked{% endif %} /> Monthly</label>
       </div>
       <div class="action-container">
         <button id="donate-button">Donate with card</span></button>

--- a/templates/subscription.html
+++ b/templates/subscription.html
@@ -3,7 +3,7 @@
 <div class="donation">
   <div class="donate-form-container">
     <div class="donate-form-header">
-      <h2>Manage Your Subscription</h2>
+      <h2>Manage Your Donation</h2>
     </div>
     <div class="donate-form-body">
       <div class="success-message">
@@ -29,6 +29,8 @@
         {% if subscription.status == 'active' %}
         <form method="post">
           <p>
+            To change your payment method or contribution level,
+            cancel your donation below and create a new one.
             If you would like to cancel your monthly donation,
             <button class="cancel-subscription" type="submit">click here</button>.
           </p>

--- a/templates/subscription.html
+++ b/templates/subscription.html
@@ -3,16 +3,21 @@
 <div class="donation">
   <div class="donate-form-container">
     <div class="donate-form-header">
-      <h2>Thank you!</h2>
+      <h2>Manage Your Subscription</h2>
     </div>
     <div class="donate-form-body">
       <div class="success-message">
         <p>
           Your <strong>{{ '$%0.2f'| format(amount/100|float) }}</strong>
-          {{ frequency }} donation by {{ payment_method }} has been collected
-          and a receipt has been sent to:<br />
+          {{ frequency }} donation by {{ payment_method }} is
+          {% if subscription.status == 'active' %}
+            active and will renew on {{ next_cycle }}.
+          {% else %}
+            canceled.
+          {% endif %}
+          The email we have on file is:<br />
           <span class="donor-email">{{ email }}</span><br><br>
-          Transaction ID:<br>
+          Subscription ID:<br>
           <span class="donor-transaction-id">{{ id }}</span><br><br>
           If you have any questions about your {{ frequency }} donation, contact us at
           <a href="mailto:{{ donate_email }}">{{ donate_email }}</a>.
@@ -21,6 +26,14 @@
           From here you can <a href="/">donate again</a> or visit
           <a href="https://www.missionbit.com/">missionbit.com</a>.
         </p>
+        {% if subscription.status == 'active' %}
+        <form method="post">
+          <p>
+            If you would like to cancel your monthly donation,
+            <button class="cancel-subscription" type="submit">click here</button>.
+          </p>
+        </form>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Allows donors to select one time or monthly donation
* URL prefill now accepts a ?frequency=monthly query string and can pass through cents to the front-end
* Uses the Pacific time zone for display of any date or time instead of UTC
* Monthly donations get a monthly receipt including a URL for managing the donation (cancel is the only option right now, they can create a new one to change amount or payment method)
* Adds a new email template for invoice failures to be sent when a subscription payment fails
* Removed some dead code from an earlier version of Stripe Checkout